### PR TITLE
Fixing wrapped_task arg in the decoder

### DIFF
--- a/cls_luigi/inhabitation_task.py
+++ b/cls_luigi/inhabitation_task.py
@@ -890,7 +890,7 @@ class CLSLuigiDecoder(cls_json.CLSDecoder):
             arg = serialized_args.pop()
             wrapped_task = wrapped_task(wrapped_task.cls.config_index.parse(arg))
         while serialized_args:
-            arg = CLSLuigiDecoder._deserialize_combinator(serialized_args.pop().values()[0])
+            arg = list(serialized_args.pop().values())[0]
             wrapped_task = wrapped_task(arg)
         return wrapped_task
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx==6.2.1
-sphinx-autoapi==2.1.0
+sphinx-autoapi==3.0.0
 sphinx-rtd-theme==1.2.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,6 @@ tox==4.5.1
 coverage==7.2.6
 Sphinx==6.2.1
 twine==4.0.2
-jinja2<3.1.2
-
+jinja2>=3.1.3
 pytest==7.3.1
 black==23.3.0


### PR DESCRIPTION
The arg for the wrapped task were returned as not as a dict. This approach was tested from Jan and Hadi on Friday 26.01.2024